### PR TITLE
NULL preserving XOR

### DIFF
--- a/killer.cpp
+++ b/killer.cpp
@@ -142,7 +142,11 @@ void deObfuscate(char* cApi, int nSize)
 {
 	for (int i = 0; i < nSize; i++)
 	{
-		cApi[i] = cApi[i] ^ KEY;
+		// try to prevent particular weakness of single-byte encoding: 
+		// It lacks the ability to effectively hide from a user manually
+		// scanning encoded content with a hex editor.     
+		if (cApi[i] != 0 && cApi[i] != KEY)
+			cApi[i] = cApi[i] ^ KEY;
 	}
 }
 


### PR DESCRIPTION
Imagine that we are malware analyst and  we investigate a malware. We know popular WinAPI strings like VirtualAlloc, CreateThread etc. We suspect that this strings (also another strings like "kernel32.dll" or "ntdll.dll") may be an XOR-encoded, but how do we find out. One of the good strategy is brute-force that works with single-byte encoding. Since there are only 256 possible values for KEY, we can try all of the possible 255 single byte key's XORed with first symbol of encoded winAPI string, compare it with the string we would expect for a winAPI string like "VirtualAlloc" or etc. For preventing this, add some changes