### PR TITLE
Fixes syntax error at line 340

### DIFF
--- a/killer.cpp
+++ b/killer.cpp
@@ -337,7 +337,7 @@ int main(int argc, char** argv) {
 	wchar_t wtk[20];
   	mbstowcs(wtk, cLib2Name, strlen(cLib2Name)+1); //plus null
   	LPWSTR wcLib2dll = wtk;
-	HMODULE hModuleK = myGetModuleHandle(wcLib2dll));
+	HMODULE hModuleK = myGetModuleHandle(wcLib2dll);
 	
 	free(pMem);
 


### PR DESCRIPTION
An extra parenthesis on line 340 was causing a compilation error. Simply removing the extra parenthesis fixed the issue and compilation completed successfully.